### PR TITLE
strip query part of url

### DIFF
--- a/JPVideoPlayer/JPVideoPlayerCache.m
+++ b/JPVideoPlayer/JPVideoPlayerCache.m
@@ -20,6 +20,7 @@
 #include <sys/param.h>
 #include <sys/mount.h>
 #import <CommonCrypto/CommonDigest.h>
+#import "NSURL+QueryStrip.h"
 
 @interface JPVideoPlayerCacheToken()
 
@@ -419,6 +420,11 @@
 }
 
 - (nullable NSString *)cachedFileNameForKey:(nullable NSString *)key {
+    if ([key length]) {
+        NSString *strippedQueryKey = [[NSURL URLWithString:key] absoluteStringByStrippingQuery];
+        key = [strippedQueryKey length] ? strippedQueryKey : key;
+    }
+    
     const char *str = key.UTF8String;
     if (str == NULL) str = "";
     unsigned char r[CC_MD5_DIGEST_LENGTH];

--- a/JPVideoPlayer/NSURL+QueryStrip.h
+++ b/JPVideoPlayer/NSURL+QueryStrip.h
@@ -1,0 +1,24 @@
+/*
+ * This file is part of the JPVideoPlayer package.
+ * (c) NewPan <13246884282@163.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Click https://github.com/Chris-Pan
+ * or http://www.jianshu.com/users/e2f2d779c022/latest_articles to contact me.
+ */
+
+
+#import <Foundation/Foundation.h>
+
+@interface NSURL (StripQuery)
+
+/*
+ * Returns absolute string of URL with the query stripped out.
+ * If there is no query, returns a copy of absolute string.
+ */
+
+- (NSString *)absoluteStringByStrippingQuery;
+
+@end

--- a/JPVideoPlayer/NSURL+QueryStrip.m
+++ b/JPVideoPlayer/NSURL+QueryStrip.m
@@ -1,0 +1,29 @@
+/*
+ * This file is part of the JPVideoPlayer package.
+ * (c) NewPan <13246884282@163.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Click https://github.com/Chris-Pan
+ * or http://www.jianshu.com/users/e2f2d779c022/latest_articles to contact me.
+ */
+
+
+#import "NSURL+QueryStrip.h"
+
+@implementation NSURL (StripQuery)
+
+- (NSString *)absoluteStringByStrippingQuery{
+    
+    NSString *absoluteString = [self absoluteString];
+    NSUInteger queryLength = [[self query] length];
+    NSString* strippedString = (queryLength ? [absoluteString substringToIndex:[absoluteString length] - (queryLength + 1)] : absoluteString);
+    
+    if ([strippedString hasSuffix:@"?"]) {
+        strippedString = [strippedString substringToIndex:absoluteString.length-1];
+    }
+    return strippedString;
+}
+
+@end


### PR DESCRIPTION
Strip video url query from cached file extension when caching video data.
If video url has query string then cached file extension contains query string.
So that, cached file not playing because of file extension.
